### PR TITLE
Include admin templates in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "python-multipart>=0.0.9",
 ]
 
+[tool.setuptools.package-data]
+"remote_browser_tool.admin" = ["templates/*.html"]
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.4",


### PR DESCRIPTION
## Summary
- configure setuptools package data to include the admin HTML templates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4844aa2cc832480f2f7888e5d35bb