### PR TITLE
Allow admin to register executors at runtime

### DIFF
--- a/src/remote_browser_tool/admin/templates/index.html
+++ b/src/remote_browser_tool/admin/templates/index.html
@@ -1,9 +1,32 @@
 {% extends "layout.html" %}
 {% block content %}
 <div class="card">
+  <h2>Connect an Executor</h2>
+  <form method="post" action="/executors" class="form-grid">
+    <div class="form-row">
+      <label for="label">Label</label>
+      <input id="label" name="label" type="text" placeholder="Optional friendly name" />
+    </div>
+    <div class="form-row">
+      <label for="base_url">Executor URL</label>
+      <input
+        id="base_url"
+        name="base_url"
+        type="url"
+        placeholder="https://executor-host:9001"
+        required
+      />
+    </div>
+    <div class="form-actions">
+      <button type="submit">Add executor</button>
+    </div>
+  </form>
+  <p class="hint">Executors can run on any host that the admin service can reach over HTTP.</p>
+</div>
+<div class="card">
   <h2>Executor Status</h2>
   {% if executors|length == 0 %}
-    <p>No executor endpoints configured. Start the admin service with the <code>--executor</code> option.</p>
+    <p>No executor endpoints configured yet. Use the form above to connect one.</p>
   {% else %}
     <table>
       <thead>
@@ -18,7 +41,10 @@
       <tbody>
         {% for item in executors %}
           <tr>
-            <td>{{ item.endpoint.label }}</td>
+            <td>
+              <div>{{ item.endpoint.label }}</div>
+              <div class="muted">{{ item.endpoint.base_url }}</div>
+            </td>
             <td>
               {% if item.error %}
                 <span class="status-pill status-unknown">Unavailable</span>

--- a/src/remote_browser_tool/admin/templates/layout.html
+++ b/src/remote_browser_tool/admin/templates/layout.html
@@ -90,6 +90,19 @@
       form textarea {
         min-height: 120px;
       }
+      .form-grid {
+        display: grid;
+        gap: 1rem;
+        max-width: 640px;
+      }
+      .form-row label {
+        margin-top: 0;
+      }
+      .form-actions {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
       button, input[type="submit"] {
         background: #2563eb;
         color: #fff;
@@ -108,6 +121,15 @@
       .error {
         color: #b91c1c;
         font-weight: 600;
+      }
+      .hint {
+        color: #4b5563;
+        margin-top: 0.75rem;
+      }
+      .muted {
+        color: #6b7280;
+        font-size: 0.9rem;
+        margin-top: 0.2rem;
       }
       .grid {
         display: grid;

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -122,6 +122,17 @@ def test_admin_portal_routes(monkeypatch) -> None:
     assert home.status_code == 200
     assert "Executor Status" in home.text
 
+    add_resp = client.post(
+        "/executors",
+        data={"label": "Secondary", "base_url": "http://other-executor"},
+        follow_redirects=False,
+    )
+    assert add_resp.status_code == 303
+    assert add_resp.headers["location"].endswith("/executors/secondary")
+
+    secondary_dashboard = client.get("/executors/secondary")
+    assert secondary_dashboard.status_code == 200
+
     dashboard = client.get("/executors/primary")
     assert dashboard.status_code == 200
     assert "Demo task" in dashboard.text


### PR DESCRIPTION
## Summary
- allow the admin service to register executor endpoints at runtime with an in-memory registry and POST route
- add a UI form for connecting executors from the admin homepage and show the executor URL in the status table
- document the new workflow for connecting executors across networks and expand admin tests for the new route

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d52679d4b883249611f7c73f832811