### PR TITLE
Improve executor registration reliability

### DIFF
--- a/src/remote_browser_tool/admin/templates/executor.html
+++ b/src/remote_browser_tool/admin/templates/executor.html
@@ -2,6 +2,14 @@
 {% block content %}
 <div class="card">
   <h2>{{ endpoint.label }} &mdash; {{ endpoint.base_url }}</h2>
+  <form
+    method="post"
+    action="/executors/{{ endpoint.key }}/delete"
+    class="inline-form"
+    style="margin-top: 0.5rem;"
+  >
+    <button type="submit" class="danger">Remove Executor</button>
+  </form>
   {% if error %}
     <p class="error">{{ error }}</p>
   {% endif %}

--- a/src/remote_browser_tool/admin/templates/index.html
+++ b/src/remote_browser_tool/admin/templates/index.html
@@ -2,6 +2,9 @@
 {% block content %}
 <div class="card">
   <h2>Connect an Executor</h2>
+  {% if error_message %}
+    <div class="alert error">{{ error_message }}</div>
+  {% endif %}
   <form method="post" action="/executors" class="form-grid">
     <div class="form-row">
       <label for="label">Label</label>
@@ -12,8 +15,8 @@
       <input
         id="base_url"
         name="base_url"
-        type="url"
-        placeholder="https://executor-host:9001"
+        type="text"
+        placeholder="executor-host:9001"
         required
       />
     </div>
@@ -75,13 +78,22 @@
               {% else %}
                 —
               {% endif %}
-            </td>
-            <td>
+          </td>
+          <td>
+            <div class="table-actions">
               <a href="/executors/{{ item.endpoint.key }}">Open</a>
-              {% if item.error %}<div class="error">{{ item.error }}</div>{% endif %}
-            </td>
-          </tr>
-        {% endfor %}
+              <form
+                method="post"
+                action="/executors/{{ item.endpoint.key }}/delete"
+                class="inline-form"
+              >
+                <button type="submit" class="danger">Remove</button>
+              </form>
+            </div>
+            {% if item.error %}<div class="error">{{ item.error }}</div>{% endif %}
+          </td>
+        </tr>
+      {% endfor %}
       </tbody>
     </table>
   {% endif %}

--- a/src/remote_browser_tool/admin/templates/layout.html
+++ b/src/remote_browser_tool/admin/templates/layout.html
@@ -115,12 +115,28 @@
       button.secondary, input.secondary {
         background: #475569;
       }
+      button.danger, input.danger {
+        background: #dc2626;
+      }
       button:hover, input[type="submit"]:hover {
         background: #1d4ed8;
+      }
+      button.danger:hover, input.danger:hover {
+        background: #b91c1c;
       }
       .error {
         color: #b91c1c;
         font-weight: 600;
+      }
+      .alert {
+        border-radius: 6px;
+        padding: 0.75rem 1rem;
+        margin-top: 1rem;
+      }
+      .alert.error {
+        background: #fee2e2;
+        border: 1px solid #fecaca;
+        color: #b91c1c;
       }
       .hint {
         color: #4b5563;
@@ -144,6 +160,16 @@
       .list li {
         padding: 0.4rem 0;
         border-bottom: 1px solid #e5e7eb;
+      }
+      .table-actions {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .inline-form {
+        display: inline;
+        margin: 0;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- normalize executor addresses, validate connectivity before registering, and reuse consistent feedback in the admin portal
- add ability to remove executor endpoints from both the status page and executor dashboard with improved UI styling
- expand admin service tests covering normalization, connection failures, and deletion workflows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5382b4e908324a3af4689480b7cba